### PR TITLE
使win32不再是必须的库，解决了Unix环境无法部署的Issue

### DIFF
--- a/office/word.py
+++ b/office/word.py
@@ -9,11 +9,11 @@
 # Description: 有关word的自动化操作
 #############################################
 
-from win32com.client import constants, gencache
 import os  # 目录的操作
 
 
 def createpdf(wordPath, pdfPath):
+    from win32com.client import constants, gencache
     word = gencache.EnsureDispatch('Word.Application')
     doc = word.Documents.Open(wordPath, ReadOnly=1)
     # 转换方法

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ rapidfuzz
 matplotlib
 imageio
 alive_progress
-pywin32
+# pywin32
 pdf2docx

--- a/service/ppt/ppt2pdf_service.py
+++ b/service/ppt/ppt2pdf_service.py
@@ -5,7 +5,6 @@ File(文件)-> Settings(设置) -> Editor(编辑器) -> Font(字体), 修改字�
 """
 
 # 1). 导入需要的模块(打开应用程序的模块)
-import win32com.client
 import os
 
 
@@ -16,6 +15,7 @@ def ppt2pdf_single(filename, output_filename):
     :param output_filename: 导出的pdf文件的名称
     :return:
     """
+    import win32com.client
     # 2). 打开PPT程序
     ppt_app = win32com.client.Dispatch('PowerPoint.Application')
     # ppt_app.Visible = True  # 程序操作应用程序的过程是否可视化

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
 	qrcode
 	translate
 	pikepdf
-	pypiwin32
+	# pywin32
 	progress
 	alive_progress
 	pdf2docx


### PR DESCRIPTION
## 解决了 #32 

Linux和macOS的用户也可以安装这个库并使用除了word和ppt的一切功能，Windows用户要想使用这些功能，也只需要额外
```shell
$ pip install pywin32
```

---

<sub>经我在centOS上测试，此commit之后确实可以成功部署并使用其他功能</sub>