### PR TITLE
搭建了单元测试框架

### DIFF
--- a/office/tests/__main__.py
+++ b/office/tests/__main__.py
@@ -1,0 +1,3 @@
+from pytest import main
+
+main()

--- a/office/tests/readme.md
+++ b/office/tests/readme.md
@@ -1,0 +1,21 @@
+# python-office 的单元测试
+
+## 使用方法
+
+> 如果没有安装`pytest`，请在终端输入以下语句安装
+> 
+> ```shell
+> & pip install pytest --upgrade 
+> ```
+
+在`office`或`office/tests`文件夹下运行
+
+```shell
+& pytest
+```
+
+或者在`office`文件夹外运行
+
+```shell
+& pytest office/tests
+```

--- a/office/tests/test_excel.py
+++ b/office/tests/test_excel.py
@@ -1,0 +1,33 @@
+def test_null():
+    assert True
+
+
+def test_import():
+    from .. import excel
+    assert excel
+    assert dir(excel)
+
+
+def test_fake2excel():
+    from ..excel import fake2excel
+    assert fake2excel
+    path = "./temp_test_fake2excel.xlsx"
+    num = 1234
+    fake2excel(rows=num, path=path)
+    from os.path import isfile
+    assert isfile(path)
+    from pandas import read_excel
+    assert len(read_excel(path, 0)) == num
+
+    fake2excel(["name", "country"], num, "english", path)
+    assert isfile(path)
+    assert read_excel(path, 0).shape == (num, 2)
+
+    # the case below will not pass until last commit
+    fake2excel(["name", "name"], num, "english", path)
+    assert isfile(path)
+    assert read_excel(path, 0).shape == (num, 2)
+
+    from os import remove
+    remove(path)
+    assert not isfile(path)

--- a/office/tests/test_file.py
+++ b/office/tests/test_file.py
@@ -1,0 +1,21 @@
+def test_import():
+    from .. import file
+    assert file
+    assert dir(file)
+
+
+def test_replace4filename():
+    path = "./temp_test_test_replace4filename.txt"
+    open(path, "w").close()
+    from os.path import isfile
+    assert isfile(path)
+    from ..file import replace4filename
+    assert replace4filename
+    replace4filename(".", "temp", "tmp")
+    assert not isfile(path)
+    path = path.replace("temp", "tmp")
+    assert path
+    assert isfile(path)
+    from os import remove
+    remove(path)
+    assert not isfile(path)


### PR DESCRIPTION
完成 #48 搭建单元测试框架

## 使用方法
在开始之前，如果没有安装pytest，请在终端输入以下语句安装
```shell
& pip install pytest --upgrade
```
---
**在office或office/tests文件夹下运行测试**
```shell
& pytest
```
**或者在office文件夹外运行测试**
```shell
& pytest office/tests
```