### PR TITLE
fix pywintypes.com_error: (-2147023174, 'RPC 服务器不可用。', None, None)

### DIFF
--- a/office/core/WordType.py
+++ b/office/core/WordType.py
@@ -27,7 +27,7 @@ class MainWord():
         for file in wordFiles:
             filepath = os.path.abspath(file)
             index = filepath.rindex('.')
-            pdfPath = filepath[:index] + '.pdf'
+            pdfPath = os.path.abspath(filepath[:index] + '.pdf')
             print(pdfPath)
             self.createpdf(filepath, pdfPath)
 


### PR DESCRIPTION
fix pywintypes.com_error: (-2147023174, 'RPC 服务器不可用。', None, None)