### PR TITLE
feat(word): 支持隐藏 doc2docx 转换进度条

### DIFF
--- a/office/api/word.py
+++ b/office/api/word.py
@@ -50,7 +50,8 @@ def merge4docx(input_path: str, output_path: str, new_word_name: str = 'merge4do
     poword.merge4docx(input_path=input_path, output_path=output_path, new_word_name=new_word_name)
 
 
-def doc2docx(input_path: str, output_path: str = r'./', output_name: str = None):
+def doc2docx(input_path: str, output_path: str = r'./', output_name: str = None,
+             show_progress: bool = True):
     """Convert Doc file to Docx file.
     
     将Doc文件转换为Docx文件。
@@ -59,11 +60,19 @@ def doc2docx(input_path: str, output_path: str = r'./', output_name: str = None)
         input_path (str): input Doc file path / 输入Doc文件的路径
         output_path (str, optional): output Docx file path / 输出Docx文件的路径。Default / 默认: current directory / 当前目录
         output_name (str, optional): output Docx file name / 输出Docx文件的名称。Default / 默认: original filename / 原文件名
+        show_progress (bool, optional): whether to show conversion progress / 是否显示转换进度条。Default / 默认: True
     
     Returns:
         None
     """
-    poword.doc2docx(input_path=input_path, output_path=output_path, output_name=output_name)
+    kwargs = {
+        'input_path': input_path,
+        'output_path': output_path,
+        'output_name': output_name,
+    }
+    if not show_progress:
+        kwargs['show_progress'] = False
+    poword.doc2docx(**kwargs)
 
 
 def docx2doc(input_path: str, output_path: str = r'./', output_name: str = None):

--- a/skills/word/doc2docx/SKILL.md
+++ b/skills/word/doc2docx/SKILL.md
@@ -23,7 +23,8 @@ from office.skills.word import doc2docx
 doc2docx(
     input_path='./old.doc',
     output_path='./',
-    output_name='new.docx'
+    output_name='new.docx',
+    show_progress=False
 )
 ```
 
@@ -34,6 +35,7 @@ doc2docx(
 | `input_path` | str | 是 | - | 输入 Doc 文件的路径 |
 | `output_path` | str | 否 | `'./'` | 输出 Docx 文件的路径 |
 | `output_name` | str | 否 | `None` | 输出 Docx 文件的名称。默认原文件名 |
+| `show_progress` | bool | 否 | `True` | 是否显示转换进度条 |
 
 ## 返回值
 

--- a/tests/test_code/test_word_api_parameters.py
+++ b/tests/test_code/test_word_api_parameters.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def load_word_api():
+    fake_poword = types.ModuleType("poword")
+    fake_poword.doc2docx = Mock()
+
+    module_path = Path(__file__).parents[2] / "office" / "api" / "word.py"
+    spec = importlib.util.spec_from_file_location("word_api_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(sys.modules, {"poword": fake_poword}):
+        spec.loader.exec_module(module)
+
+    return module, fake_poword
+
+
+class TestDoc2DocxParameters(unittest.TestCase):
+    def setUp(self):
+        self.word_api, self.poword = load_word_api()
+
+    def test_keeps_default_call_compatible(self):
+        self.word_api.doc2docx("source.doc", "output", "result.docx")
+
+        self.poword.doc2docx.assert_called_once_with(
+            input_path="source.doc",
+            output_path="output",
+            output_name="result.docx",
+        )
+
+    def test_forwards_hidden_progress_option(self):
+        self.word_api.doc2docx(
+            "source.doc",
+            "output",
+            "result.docx",
+            show_progress=False,
+        )
+
+        self.poword.doc2docx.assert_called_once_with(
+            input_path="source.doc",
+            output_path="output",
+            output_name="result.docx",
+            show_progress=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

解决 #139：允许调用 `office.word.doc2docx` 时隐藏转换进度条。

## 修改

- 为公开 API 增加 `show_progress: bool = True`
- 显式传入 `False` 时向底层传递隐藏选项
- 默认调用不传递新关键字，保持与旧版 `poword` 的兼容性
- 更新 docstring 和 doc2docx Skill 文档
- 增加参数转发单元测试

## 依赖

依赖底层 PR CoderWanFeng/poword#3。

## 测试

```bash
python3 -m unittest tests.test_code.test_word_api_parameters -v
```

Fixes #139