### PR TITLE
Support full output path in doc2docx

### DIFF
--- a/office/api/word.py
+++ b/office/api/word.py
@@ -14,6 +14,8 @@ Author:
 Project:
     https://www.python-office.com
 """
+from pathlib import Path
+
 
 def _load_poword():
     try:
@@ -69,12 +71,17 @@ def doc2docx(input_path: str, output_path: str = r'./', output_name: str = None)
     
     Args:
         input_path (str): input Doc file path / 输入Doc文件的路径
-        output_path (str, optional): output Docx file path / 输出Docx文件的路径。Default / 默认: current directory / 当前目录
+        output_path (str, optional): output Docx file path / 输出Docx文件的路径。Can be a directory or a .docx file path / 可以是目录或 .docx 文件路径。Default / 默认: current directory / 当前目录
         output_name (str, optional): output Docx file name / 输出Docx文件的名称。Default / 默认: original filename / 原文件名
     
     Returns:
         None
     """
+    if output_name is None and Path(output_path).suffix.lower() == ".docx":
+        output_file = Path(output_path)
+        output_path = str(output_file.parent)
+        output_name = output_file.name
+
     poword = _load_poword()
     poword.doc2docx(input_path=input_path, output_path=output_path, output_name=output_name)
 

--- a/skills/word/doc2docx/SKILL.md
+++ b/skills/word/doc2docx/SKILL.md
@@ -27,12 +27,23 @@ doc2docx(
 )
 ```
 
+也可以直接把目标文件路径传给 `output_path`：
+
+```python
+from office.skills.word import doc2docx
+
+doc2docx(
+    input_path='./old.doc',
+    output_path='./new/new.docx'
+)
+```
+
 ## 参数说明
 
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | `input_path` | str | 是 | - | 输入 Doc 文件的路径 |
-| `output_path` | str | 否 | `'./'` | 输出 Docx 文件的路径 |
+| `output_path` | str | 否 | `'./'` | 输出 Docx 文件的路径，可以是输出目录，也可以是完整的 `.docx` 文件路径 |
 | `output_name` | str | 否 | `None` | 输出 Docx 文件的名称。默认原文件名 |
 
 ## 返回值
@@ -44,6 +55,11 @@ doc2docx(
 ```python
 from office.skills.word import doc2docx
 doc2docx(input_path='./old.doc', output_path='./new/')
+```
+
+```python
+from office.skills.word import doc2docx
+doc2docx(input_path='./old.doc', output_path='./new/new.docx')
 ```
 
 ## 原始函数

--- a/tests/test_code/test_word_doc2docx_output_path.py
+++ b/tests/test_code/test_word_doc2docx_output_path.py
@@ -1,0 +1,43 @@
+"""Tests for doc2docx output path handling."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from office.api import word as word_api
+
+
+class TestDoc2DocxOutputPath(unittest.TestCase):
+    def test_doc2docx_accepts_full_output_file_path(self):
+        poword = Mock()
+
+        with patch.object(word_api, "_load_poword", return_value=poword):
+            word_api.doc2docx(
+                input_path="source.doc",
+                output_path="converted/result.docx",
+            )
+
+        poword.doc2docx.assert_called_once_with(
+            input_path="source.doc",
+            output_path="converted",
+            output_name="result.docx",
+        )
+
+    def test_doc2docx_keeps_directory_output_path(self):
+        poword = Mock()
+
+        with patch.object(word_api, "_load_poword", return_value=poword):
+            word_api.doc2docx(
+                input_path="source.doc",
+                output_path="converted",
+                output_name="result.docx",
+            )
+
+        poword.doc2docx.assert_called_once_with(
+            input_path="source.doc",
+            output_path="converted",
+            output_name="result.docx",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow office.word.doc2docx to accept a full .docx file path in output_path when output_name is not provided
- keep the existing output directory + output_name behavior unchanged
- update the doc2docx Skill documentation and add a mock-based regression test

## Context
Refs #121

## Verification
- .\\.python312\\python.exe -m py_compile office\\api\\word.py tests\\test_code\\test_word_doc2docx_output_path.py
- .\\.python312\\python.exe -m unittest tests.test_code.test_word_doc2docx_output_path