### PR TITLE
contrib: 新增hs5057 md-studio联动转换示例

### DIFF
--- a/contributors/hs5057/md_office_demo.py
+++ b/contributors/hs5057/md_office_demo.py
@@ -1,0 +1,31 @@
+"""
+md-studio + python-office 联动极简示例
+功能流程：
+1. 使用 md-studio 将 markdown 文件转为 Word
+2. 使用 python-office 读取、修改生成后的 Word 文件
+"""
+
+# 安装依赖命令
+# pip install python-office md-studio
+
+import office
+# 导入md-studio转换工具
+from md_studio.converter import MdToWord
+
+def simple_md_office_flow():
+    # 1. md 转 word
+    converter = MdToWord()
+    converter.convert("demo.md", "output.docx")
+
+    # 2. 使用 python-office 读取生成的word文档
+    word = office.Word("output.docx")
+    content = word.read_text()
+    print("读取到md转换后的文档内容：", content[:100])
+
+    # 3. 追加一行文本到word
+    word.add_paragraph("本文件由 md-studio + python-office 联合处理")
+    word.save()
+    print("文档处理完成！")
+
+if __name__ == "__main__":
+    simple_md_office_flow()

--- a/contributors/hs5057/readme.md
+++ b/contributors/hs5057/readme.md
@@ -1,0 +1,5 @@
+# md-studio + python-office 联动示例
+配套开源项目：https://github.com/hs5057/md-studio
+项目功能：Python 实现 Markdown <-> Word/PDF/HTML 双向文档转换服务
+
+本示例演示如何结合 md-studio 与 python-office，完成完整办公文档流转，仅做生态互补演示，不改动项目核心代码。


### PR DESCRIPTION
## 本次改动
1. 在 contributors/ 目录新建 hs5057 专属文件夹
2. 新增 md-studio + python-office 极简联动示例代码
3. 配套说明文档，介绍互补开源项目 md-studio

## 补充说明
md-studio 主打Markdown与Office文档双向转换，可与本项目搭配覆盖完整文档自动化流程。
本人正在申请 OpenAI Codex for Open Source 开源维护扶持，后续会持续更新本文件夹内的转换示例。

## 合规说明
仅新增 contributors/hs5057 文件夹，未修改仓库任何原有代码与文件，完全遵循项目贡献规范。